### PR TITLE
Bugfix/search not adding proxy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,7 @@
 # The .vscode folder contains launch configuration and tasks you configure in
 # VS Code which you may wish to be included in version control, so this line
 # is commented out by default.
-#.vscode/
+.vscode/
 
 # Flutter/Dart/Pub related
 **/doc/api/

--- a/lib/google_place.dart
+++ b/lib/google_place.dart
@@ -72,15 +72,22 @@ class GooglePlace {
   /// http proxies are supported, but are not recommended for production use.
   final String? proxyUrl;
 
+  /// Optional: include protocol in proxy url path.  Need to set true when using
+  /// proxy server hosted in Azure.
+  final bool includeProtocol;
+
   GooglePlace(
     this.apiKEY, {
     this.headers = const {},
     this.proxyUrl,
+    this.includeProtocol = true,
   }) {
-    this.search = Search(apiKEY, headers, proxyUrl);
-    this.details = Details(apiKEY, headers, proxyUrl);
-    this.photos = Photos(apiKEY, headers, proxyUrl);
-    this.autocomplete = Autocomplete(apiKEY, headers, proxyUrl);
-    this.queryAutocomplete = QueryAutocomplete(apiKEY, headers, proxyUrl);
+    this.search = Search(apiKEY, headers, proxyUrl, includeProtocol);
+    this.details = Details(apiKEY, headers, proxyUrl, includeProtocol);
+    this.photos = Photos(apiKEY, headers, proxyUrl, includeProtocol);
+    this.autocomplete =
+        Autocomplete(apiKEY, headers, proxyUrl, includeProtocol);
+    this.queryAutocomplete =
+        QueryAutocomplete(apiKEY, headers, proxyUrl, includeProtocol);
   }
 }

--- a/lib/src/autocomplete/autocomplete.dart
+++ b/lib/src/autocomplete/autocomplete.dart
@@ -7,8 +7,9 @@ class Autocomplete {
   final String apiKEY;
   final Map<String, String> headers;
   final String? proxyUrl;
+  final bool includeProtocol;
 
-  Autocomplete(this.apiKEY, this.headers, this.proxyUrl);
+  Autocomplete(this.apiKEY, this.headers, this.proxyUrl, this.includeProtocol);
 
   /// The Place Autocomplete service is a web service that returns place predictions in response
   ///  to an HTTP request. The request specifies a textual search string and optional geographic
@@ -100,11 +101,8 @@ class Autocomplete {
     );
 
     var uri = NetworkUtility.createUri(
-      proxyUrl,
-      _authority,
-      _unencodedPath,
-      queryParameters,
-    );
+        proxyUrl, _authority, _unencodedPath, queryParameters,
+        includeProtocol: includeProtocol);
     var response = await NetworkUtility.fetchUrl(uri, headers: headers);
     if (response != null) {
       return AutocompleteResponse.parseAutocompleteResult(response);

--- a/lib/src/details/details.dart
+++ b/lib/src/details/details.dart
@@ -8,8 +8,9 @@ class Details {
   final String apiKEY;
   final Map<String, String> headers;
   final String? proxyUrl;
+  final bool includeProtocol;
 
-  Details(this.apiKEY, this.headers, this.proxyUrl);
+  Details(this.apiKEY, this.headers, this.proxyUrl, this.includeProtocol);
 
   /// Once you have a place_id from a Place Search, you can request more details about a
   /// particular establishment or point of interest by initiating a Place Details request.
@@ -53,11 +54,8 @@ class Details {
       fields,
     );
     var uri = NetworkUtility.createUri(
-      proxyUrl,
-      _authority,
-      _unencodedPath,
-      queryParameters,
-    );
+        proxyUrl, _authority, _unencodedPath, queryParameters,
+        includeProtocol: includeProtocol);
     var response = await NetworkUtility.fetchUrl(uri, headers: headers);
     if (response != null) {
       return DetailsResponse.parseDetailsResult(response);

--- a/lib/src/photos/photos.dart
+++ b/lib/src/photos/photos.dart
@@ -8,8 +8,9 @@ class Photos {
   final String apiKEY;
   final Map<String, String> headers;
   final String? proxyUrl;
+  final bool includeProtocol;
 
-  Photos(this.apiKEY, this.headers, this.proxyUrl);
+  Photos(this.apiKEY, this.headers, this.proxyUrl, this.includeProtocol);
 
   /// The Place Photo service, part of the Places API, is a read- only API that allows you to
   /// add high quality photographic content to your application. The Place Photo service gives
@@ -41,7 +42,8 @@ class Photos {
       maxWidth,
     );
     var uri = NetworkUtility.createUri(
-        proxyUrl, _authority, _unencodedPath, queryParameters);
+        proxyUrl, _authority, _unencodedPath, queryParameters,
+        includeProtocol: includeProtocol);
     var response = await NetworkUtility.fetchUrl(uri, headers: headers);
     if (response != null) {
       List<int> list = response.codeUnits;

--- a/lib/src/query_autocomplete/query_autocomplete.dart
+++ b/lib/src/query_autocomplete/query_autocomplete.dart
@@ -7,8 +7,10 @@ class QueryAutocomplete {
   final String apiKEY;
   final Map<String, String> headers;
   final String? proxyUrl;
+  final bool includeProtocol;
 
-  QueryAutocomplete(this.apiKEY, this.headers, this.proxyUrl);
+  QueryAutocomplete(
+      this.apiKEY, this.headers, this.proxyUrl, this.includeProtocol);
 
   /// The Query Autocomplete service can be used to provide a query prediction for text-based
   /// geographic searches, by returning suggested queries as you type.
@@ -49,7 +51,8 @@ class QueryAutocomplete {
       language,
     );
     var uri = NetworkUtility.createUri(
-        proxyUrl, _authority, _unencodedPath, queryParameters);
+        proxyUrl, _authority, _unencodedPath, queryParameters,
+        includeProtocol: includeProtocol);
     var response = await NetworkUtility.fetchUrl(uri, headers: headers);
     if (response != null) {
       return AutocompleteResponse.parseAutocompleteResult(response);
@@ -97,7 +100,8 @@ class QueryAutocomplete {
     );
 
     var uri = NetworkUtility.createUri(
-        proxyUrl, _authority, _unencodedPath, queryParameters);
+        proxyUrl, _authority, _unencodedPath, queryParameters,
+        includeProtocol: includeProtocol);
     return await NetworkUtility.fetchUrl(uri, headers: headers);
   }
 

--- a/lib/src/search/search.dart
+++ b/lib/src/search/search.dart
@@ -10,8 +10,9 @@ class Search {
   final String apiKEY;
   final Map<String, String> headers;
   final String? proxyUrl;
+  final bool includeProtocol;
 
-  Search(this.apiKEY, this.headers, this.proxyUrl);
+  Search(this.apiKEY, this.headers, this.proxyUrl, this.includeProtocol);
 
   /// A Find Place request takes a text input and returns a place.
   /// The input can be any kind of Places text data, such as a name, address, or phone number.
@@ -51,7 +52,8 @@ class Search {
     );
 
     var uri = NetworkUtility.createUri(
-        proxyUrl, _authority, _unencodedPathFindPlace, queryParameters);
+        proxyUrl, _authority, _unencodedPathFindPlace, queryParameters,
+        includeProtocol: includeProtocol);
     var response = await NetworkUtility.fetchUrl(uri, headers: headers);
     if (response != null) {
       return FindPlaceResponse.parseFindPlaceResult(response);
@@ -127,7 +129,8 @@ class Search {
     );
 
     final uri = NetworkUtility.createUri(
-        proxyUrl, _authority, _unencodedPathNearBySearch, queryParameters);
+        proxyUrl, _authority, _unencodedPathNearBySearch, queryParameters,
+        includeProtocol: includeProtocol);
     final response = await NetworkUtility.fetchUrl(uri, headers: headers);
     if (response != null) {
       return NearBySearchResponse.parseNearBySearchResult(response);

--- a/lib/src/search/search.dart
+++ b/lib/src/search/search.dart
@@ -111,7 +111,7 @@ class Search {
     String? type,
     String? pagetoken,
   }) async {
-    var queryParameters = _createNearBySearchParameters(
+    final queryParameters = _createNearBySearchParameters(
       apiKEY,
       location,
       radius,
@@ -126,9 +126,9 @@ class Search {
       pagetoken,
     );
 
-    var uri =
-        Uri.https(_authority, _unencodedPathNearBySearch, queryParameters);
-    var response = await NetworkUtility.fetchUrl(uri, headers: headers);
+    final uri = NetworkUtility.createUri(
+        proxyUrl, _authority, _unencodedPathNearBySearch, queryParameters);
+    final response = await NetworkUtility.fetchUrl(uri, headers: headers);
     if (response != null) {
       return NearBySearchResponse.parseNearBySearchResult(response);
     }

--- a/lib/src/utils/network_utility.dart
+++ b/lib/src/utils/network_utility.dart
@@ -25,7 +25,8 @@ class NetworkUtility {
   /// [unencodedGoogleMapsPath] Required parameters - the path to the api, usually something like maps/api/...
   /// [queryParameters] Required parameters - a map of query parameters to be appended to the url
   static Uri createUri(String? proxyUrl, String authority,
-      String unencodedGoogleMapsPath, Map<String, String?> queryParameters) {
+      String unencodedGoogleMapsPath, Map<String, String?> queryParameters,
+      {bool includeProtocol = true}) {
     Uri uri;
     final googleApiUri = Uri.https(
       authority,
@@ -75,19 +76,25 @@ class NetworkUtility {
         }
       } else {
         //no parameter
+        if (!includeProtocol) {
+          return Uri.https(
+            proxyHostname,
+            '$everythingAfterHostname$authority:443/$unencodedGoogleMapsPath',
+            queryParameters,
+          );
+        }
         if (usingHttps) {
-          uri = Uri.https(
+          return Uri.https(
             proxyHostname,
             '${everythingAfterHostname}https://$authority/$unencodedGoogleMapsPath',
             queryParameters,
           );
-        } else {
-          uri = Uri.http(
-            proxyHostname,
-            '${everythingAfterHostname}http://$authority/$unencodedGoogleMapsPath',
-            queryParameters,
-          );
         }
+        return Uri.http(
+          proxyHostname,
+          '${everythingAfterHostname}http://$authority/$unencodedGoogleMapsPath',
+          queryParameters,
+        );
       }
     } else {
       uri = googleApiUri;


### PR DESCRIPTION
If proxy is hosted on Azure, the target URL cannot include https or http, it must use port instead.